### PR TITLE
Update URLs to point specifically to v1 of the `@solana/web3.js` docs

### DIFF
--- a/docs/src/single-pool.mdx
+++ b/docs/src/single-pool.mdx
@@ -129,7 +129,7 @@ const connection = new Connection(clusterApiUrl('devnet'), 'confirmed');
 ```
 
 ### Keypair
-You can either get your keypair using [`Keypair`](https://solana-labs.github.io/solana-web3.js/classes/Keypair.html) from `@solana/web3.js`, or let the user's wallet handle the keypair and use `sendTransaction` from [`wallet-adapter`](https://github.com/solana-labs/wallet-adapter)
+You can either get your keypair using [`Keypair`](https://solana-labs.github.io/solana-web3.js/v1.x/classes/Keypair.html) from `@solana/web3.js`, or let the user's wallet handle the keypair and use `sendTransaction` from [`wallet-adapter`](https://github.com/solana-labs/wallet-adapter)
 
   </TabItem>
   <TabItem value="jsn" label="WEB3.JS NEXT">

--- a/docs/src/token.mdx
+++ b/docs/src/token.mdx
@@ -113,7 +113,7 @@ const web3 = require('@solana/web3.js');
 const connection = new web3.Connection(web3.clusterApiUrl('devnet'), 'confirmed');
 ```
 ### Keypair
-You can either get your keypair using [`Keypair`](https://solana-labs.github.io/solana-web3.js/classes/Keypair.html) from `@solana/web3.js`, or let the user's wallet handle the keypair and use `sendTransaction` from [`wallet-adapter`](https://github.com/solana-labs/wallet-adapter)
+You can either get your keypair using [`Keypair`](https://solana-labs.github.io/solana-web3.js/v1.x/classes/Keypair.html) from `@solana/web3.js`, or let the user's wallet handle the keypair and use `sendTransaction` from [`wallet-adapter`](https://github.com/solana-labs/wallet-adapter)
 
   </TabItem>
 </Tabs>


### PR DESCRIPTION

Read more: https://github.com/solana-labs/solana-web3.js/issues/3498